### PR TITLE
redis: fix refresh manager race (#10727)

### DIFF
--- a/source/extensions/common/redis/cluster_refresh_manager_impl.cc
+++ b/source/extensions/common/redis/cluster_refresh_manager_impl.cc
@@ -73,6 +73,47 @@ bool ClusterRefreshManagerImpl::onEvent(const std::string& cluster_name, EventTy
       if (threshold <= 0) {
         return false;
       }
+
+      // There're 3 updates to atomic values cross threads in this section of code
+      // a) ++(*count) >= threshold
+      // b) info->last_callback_time_ms_.compare_exchange_strong(last_callback_time_ms, now)
+      // c) *count = 0
+      // Let's say there're 2 threads T1 and T2, for all legal permutation of execution order a, b,
+      // c we need to ensure that post_callback is true for only 1 thread and if both a) and b) are
+      // true in 1 thread the count is 0 after this section. Here's a few different sequence that
+      // can potentially result in race conditions to consider
+
+      // Sequence 1:
+      // starting condition: threshold:2, count:1, T1.last_call_back = T2.last_call_back =
+      // info.last_call_back
+      // * T1.a (count: 2)
+      // * T1.b succeed (info.last_call_back: T1.now, T1.post_callback: true)
+      // * T1.c (count:0)
+      // * T2.a (count: 1, T2.post_callback: false)
+      // * T2.b is skip since T2.a is false
+      // * T2.c will still be triggered since info.last_call_back is now changed by T1 (count: 0)
+      //
+      // Sequence 2:
+      // starting condition: threshold:2, count:1, T1.last_call_back = T2.last_call_back =
+      // info.last_call_back
+      // * T1.a (count: 2)
+      // * T2.a (count: 3)
+      // * T1.b succeed (info.last_call_back: T1.now, post_callback: true)
+      // * T2.b failed due since info.last_call_back is now T1.now
+      // * T1.c (count:0)
+      // * T2.c (count:0) note we can't use count.decrement here since count is already 0
+      //
+      // Sequence 3:
+      // starting condition: threshold:2, count:1, T1.last_call_back == T2.last_call_back ==
+      // info.last_call_back
+      // * T1.a (count: 1, T1.post_callback: false)
+      // * T1.b skip since T1.a is false
+      // * T2.a (count: 2, T2.post_callback: true)
+      // * T2.b succeed (info.last_call_back = T2.now)
+      // * T2.c (count: 0)
+      // * T1.c will be triggered since info.last_call_back is changed by T2 (count: 0)
+
+      bool post_callback = false;
       // ignore redirects during min time between triggering
       if ((++(*count) >= threshold) &&
           (info->last_callback_time_ms_.compare_exchange_strong(last_callback_time_ms, now))) {
@@ -80,7 +121,16 @@ bool ClusterRefreshManagerImpl::onEvent(const std::string& cluster_name, EventTy
         // initially read. This thread is allowed to post a call to the registered callback
         // on the main thread. Otherwise, the thread would be ignored to prevent over-triggering
         // cluster callbacks.
+        post_callback = true;
+      }
+
+      // If a callback should be triggered(in this or some other thread) signaled by the changed
+      // last callback time, we reset the count to 0
+      if (post_callback || info->last_callback_time_ms_.load() != last_callback_time_ms) {
         *count = 0;
+      }
+
+      if (post_callback) {
         main_thread_dispatcher_.post([this, cluster_name, info]() {
           // Ensure that cluster is still active before calling callback.
           auto map = cm_.clusters();


### PR DESCRIPTION
Signed-off-by: Henry Yang <hyang@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
